### PR TITLE
Add Mercedes-Benz GLA 250 generations data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Mercedes-Benz GLA 250
 
+This repository contains signal set configurations for the Mercedes-Benz GLA 250, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Mercedes-Benz GLA 250.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,0 +1,15 @@
+references:
+  - "https://en.wikipedia.org/wiki/Mercedes-Benz_GLA"
+
+generations:
+  - name: "First Generation"
+    start_year: 2013
+    end_year: 2019
+    model_code: "X156"
+    description: "The first generation Mercedes-Benz GLA 250 was produced from December 2013 to November 2019 as a subcompact luxury crossover SUV. It featured a 2.0L turbocharged four-cylinder petrol engine producing 155 kW (211 PS) and 350 Nm of torque, with a 0-100 km/h acceleration of 6.7 seconds and 230 km/h top speed."
+
+  - name: "Second Generation"
+    start_year: 2019
+    end_year: null
+    model_code: "H247"
+    description: "The second generation Mercedes-Benz GLA 250 was introduced in December 2019 and continues to the present. It features an updated design with improved interior space, MBUX infotainment system, and a 2.0L turbocharged four-cylinder petrol engine producing 165 kW (224 PS) and 350 Nm of torque, with 0-100 km/h acceleration of 6.9 seconds and 250 km/h top speed."


### PR DESCRIPTION
- Create generations.yaml with two generations (X156: 2013-2019, H247: 2019-present)
- Add detailed specifications for GLA 250 petrol engines for both generations
- Update README.md with standard template
- Reference Wikipedia article for generation information

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
